### PR TITLE
Changing DataflowFramework To use Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# LLVM Compiler Optimizations
+LLVM Compiler Optimization Course homework repo for SengMing and Ashwin
+
+## Requirements:
+LLVM and Clang 6.0.1
+
+## Assignment 1:
+### Function Information LLVM Pass:
+Analysis pass using a FunctionPass. Spits out the following details about a function:
+    
+    - Name.
+    - Number of arguments.
+    - Number of Direct call sites in the same module.
+    - Number of basic blocks.
+    - Number of instructions.
+    - Number of add, sub, mul, div, and branch instructions.
+
+Local Optimization Pass to perform basic-block level optimizations, for example:
+1) Algebraic Identities: eg. x + 0 = 0 + x => x
+2) Local Binary Expression Constant Folding: eg. 2*4 => 8
+3) Strength reduction: eg. 2*x => (x<<1)
+
+## Assignment 2:
+### Data flow Analysis framework:
+General framework to break-down any unidirectional data-flow problem into well-defined set of components. It should consist of the following:
+1) Domain the analysis operates on: eg. All subsets of variable definitions in module.
+2) Direction, forwards or backwards analysis pass.
+3) Transfer function
+4) Meet Operator
+5) Boundary Condition
+6) Initial Interior Points (Initialization of IN and OUT sets)

--- a/assignment2/SourceCode/DataflowFramework/dataflow.cpp
+++ b/assignment2/SourceCode/DataflowFramework/dataflow.cpp
@@ -1,45 +1,11 @@
 
 ////////////////////////////////////////////////////////////////////////////////
-#include "dataflow.h"
+//#include "dataflow.h"
+#include <dataflow.h>
 #include <llvm/ADT/PostOrderIterator.h>
 #include <llvm/Support/raw_ostream.h>
 
 namespace llvm {
 // Add code for your dataflow abstraction here.
-
-DataflowFramework::DataflowFramework(IMeetOp &meetOp, FlowDirection direction,
-                                     Function &function)
-    : m_meetOp(meetOp), m_func(function), m_dir(direction) {}
-
-void DataflowFramework::run() {
-    if (m_dir == FORWARD) {
-        doForwardTraversal();
-    } else {
-        doBackwardTraversal();
-    }
-}
-
-void DataflowFramework::doForwardTraversal() {
-    // For now this will suffice, but we need to be wary of multiple return
-    // statements, if that is present in the program. In LLVM there can be
-    // multiple terminator instructions that are returns in a basic block. There
-    // is no 'EXIT' block for the procedure. This means our ipo_begin
-    // instantiation might not be 100% accurate. This also applies for
-    // post_order.
-    for (ipo_iterator<BasicBlock *> I =
-             ipo_begin(&m_func.getBasicBlockList().back());
-         I != ipo_end(&m_func.getEntryBlock()); ++I) {
-        if (BasicBlock *BB = dyn_cast<BasicBlock>(*I))
-            outs() << *BB << "\n";
-    }
-}
-
-void DataflowFramework::doBackwardTraversal() {
-    for (po_iterator<BasicBlock *> I = po_begin(&m_func.getEntryBlock());
-         I != po_end(&m_func.getBasicBlockList().back()); ++I) {
-        if (BasicBlock *BB = dyn_cast<BasicBlock>(*I))
-            outs() << *BB << "\n";
-    }
-}
 
 } // namespace llvm

--- a/assignment2/SourceCode/DataflowFramework/include/dataflow.h
+++ b/assignment2/SourceCode/DataflowFramework/include/dataflow.h
@@ -3,12 +3,17 @@
 
 #ifndef __CLASSICAL_DATAFLOW_H__
 #define __CLASSICAL_DATAFLOW_H__
-
+// llvm based
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/ValueMap.h"
+#include <llvm/ADT/PostOrderIterator.h>
+#include <llvm/Support/raw_ostream.h>
+
+// std
+#include <vector>
 
 // Local includes:
 #include <MeetOpInterface.h>
@@ -20,11 +25,12 @@ namespace llvm {
 
 // Add definitions (and code, depending on your strategy) for your dataflow
 // abstraction here.
-class DataflowFramework {
+template <typename D> class DataflowFramework {
   protected:
     IMeetOp &m_meetOp;
     Function &m_func;
     FlowDirection m_dir;
+    std::vector<D> &m_domainSet;
 
     void doForwardTraversal();
     void doBackwardTraversal();
@@ -39,14 +45,54 @@ class DataflowFramework {
     // 6) Boundary Condition
     // 7) Sets of Expressions/Variables
     DataflowFramework(IMeetOp &meetOp, FlowDirection direction,
-                      Function &function);
+                      Function &function, std::vector<D> &domainset);
 
     // Placeholder function for entire computation, we may use template later,
     // depending on how we want to return the results and what results to
     // return. Eg: vector<Expression>? or vector<Variable>? We might use
     // vector<T> to template it.
-    void run();
+    std::vector<D> &run();
 };
+
+template <typename D>
+DataflowFramework<D>::DataflowFramework(IMeetOp &meetOp,
+                                        FlowDirection direction,
+                                        Function &function,
+                                        std::vector<D> &domainset)
+    : m_meetOp(meetOp), m_func(function), m_dir(direction),
+      m_domainSet(domainset) {}
+
+template <typename D> std::vector<D> &DataflowFramework<D>::run() {
+    if (m_dir == FORWARD) {
+        doForwardTraversal();
+    } else {
+        doBackwardTraversal();
+    }
+    return m_domainSet;
+}
+
+template <typename D> void DataflowFramework<D>::doForwardTraversal() {
+    // For now this will suffice, but we need to be wary of multiple return
+    // statements, if that is present in the program. In LLVM there can be
+    // multiple terminator instructions that are returns in a basic block. There
+    // is no 'EXIT' block for the procedure. This means our ipo_begin
+    // instantiation might not be 100% accurate. This also applies for
+    // post_order.
+    for (ipo_iterator<BasicBlock *> I =
+             ipo_begin(&m_func.getBasicBlockList().back());
+         I != ipo_end(&m_func.getEntryBlock()); ++I) {
+        if (BasicBlock *BB = dyn_cast<BasicBlock>(*I))
+            outs() << *BB << "\n";
+    }
+}
+
+template <typename D> void DataflowFramework<D>::doBackwardTraversal() {
+    for (po_iterator<BasicBlock *> I = po_begin(&m_func.getEntryBlock());
+         I != po_end(&m_func.getBasicBlockList().back()); ++I) {
+        if (BasicBlock *BB = dyn_cast<BasicBlock>(*I))
+            outs() << *BB << "\n";
+    }
+}
 
 } // namespace llvm
 

--- a/assignment2/SourceCode/available.cpp
+++ b/assignment2/SourceCode/available.cpp
@@ -52,7 +52,7 @@ class AvailableExpressions : public FunctionPass {
         // Instantiate requirements
         IntersectionMeet intersect;
 
-        DataflowFramework DF(intersect, FORWARD, F);
+        DataflowFramework<Expression> DF(intersect, FORWARD, F, expressions);
         DF.run();
 
         // Did not modify the incoming Function.


### PR DESCRIPTION
Minor changes,
We are making DataflowFramework a template class so we can pass in the
type it's working on. Cpp templates can only have definitions in header
file, so we might delete dataflow.cpp if required later on, for now we
leave it and put the entire definition of DataflowFramework template in dataflow.h

In addition, we also added the expression vector to arguments we get in
the constructor. This is done because we want ownership or instantiation
of the domain set vector to be done externally. We should try to have
memory management (instantiation and destruction) of these in a common
place (usually a factory, but we don't need that in this case).

Depending on implementation details, we may pass in an already populated
set, or we can pass in the memory and then populate the set internally
in the DataflowFramework class.
